### PR TITLE
void return types

### DIFF
--- a/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -25,7 +25,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
     /**
      * @inheritdoc
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('Limenius\Liform\Liform')) {
             return;

--- a/DependencyInjection/Compiler/TransformerCompilerPass.php
+++ b/DependencyInjection/Compiler/TransformerCompilerPass.php
@@ -26,7 +26,7 @@ class TransformerCompilerPass implements CompilerPassInterface
     /**
      * @inheritdoc
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->hasDefinition('Limenius\Liform\Resolver')) {
             return;

--- a/DependencyInjection/LimeniusLiformExtension.php
+++ b/DependencyInjection/LimeniusLiformExtension.php
@@ -28,7 +28,7 @@ class LimeniusLiformExtension extends Extension
     /**
      * @inheritdoc
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('transformers.xml');


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Limenius\LiformBundle\DependencyInjection\LimeniusLiformExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Limenius\LiformBundle\DependencyInjection\Compiler\TransformerCompilerPass" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Limenius\LiformBundle\DependencyInjection\Compiler\ExtensionCompilerPass" now to avoid errors or add an explicit @return annotation to suppress this message.